### PR TITLE
SIR-1790 Vault can't sign a transaction to the non-segwit LTC address

### DIFF
--- a/src/main/java/io/swisschain/crypto/altcoins/litecoin/RegTestParams.java
+++ b/src/main/java/io/swisschain/crypto/altcoins/litecoin/RegTestParams.java
@@ -3,21 +3,19 @@ package io.swisschain.crypto.altcoins.litecoin;
 public class RegTestParams extends org.bitcoinj.params.RegTestParams {
   public RegTestParams() {
     super();
-    packetMagic = 0xf1c8d2fd;
+    packetMagic = 0xdab5bffa;
     addressHeader = 111;
     p2shHeader = 58;
     targetTimespan = TARGET_TIMESPAN;
     dumpedPrivateKeyHeader = 239;
-    segwitAddressHrp = "tltc";
+    segwitAddressHrp = "rltc";
     spendableCoinbaseDepth = 100;
     dnsSeeds = null;
     addrSeeds = null;
     bip32HeaderP2PKHpub = 0x043587cf; // The 4 byte header that serializes in base58 to "tpub".
     bip32HeaderP2PKHpriv = 0x04358394; // The 4 byte header that serializes in base58 to "tprv"
-    bip32HeaderP2WPKHpub = 0x045f1cf6; // The 4 byte header that serializes in base58 to "vpub".
-    bip32HeaderP2WPKHpriv = 0x045f18bc; // The 4 byte header that serializes in base58 to "vprv"
 
-    id = ID_REGTEST;
+    id = "ltc-reg";
 
     majorityEnforceBlockUpgrade = MainNetParams.MAINNET_MAJORITY_ENFORCE_BLOCK_UPGRADE;
     majorityRejectBlockOutdated = MainNetParams.MAINNET_MAJORITY_REJECT_BLOCK_OUTDATED;

--- a/src/main/java/io/swisschain/crypto/altcoins/litecoin/TestNet3Params.java
+++ b/src/main/java/io/swisschain/crypto/altcoins/litecoin/TestNet3Params.java
@@ -3,19 +3,21 @@ package io.swisschain.crypto.altcoins.litecoin;
 public class TestNet3Params extends org.bitcoinj.params.TestNet3Params {
   public TestNet3Params() {
     super();
-    packetMagic = 0xdab5bffa;
+    packetMagic = 0xf1c8d2fd;
     addressHeader = 111;
     p2shHeader = 58;
     targetTimespan = TARGET_TIMESPAN;
     dumpedPrivateKeyHeader = 239;
-    segwitAddressHrp = "rltc";
+    segwitAddressHrp = "tltc";
     spendableCoinbaseDepth = 100;
     dnsSeeds = null;
     addrSeeds = null;
     bip32HeaderP2PKHpub = 0x043587cf; // The 4 byte header that serializes in base58 to "tpub".
     bip32HeaderP2PKHpriv = 0x04358394; // The 4 byte header that serializes in base58 to "tprv"
+    bip32HeaderP2WPKHpub = 0x045f1cf6; // The 4 byte header that serializes in base58 to "vpub".
+    bip32HeaderP2WPKHpriv = 0x045f18bc; // The 4 byte header that serializes in base58 to "vprv"
 
-    id = ID_TESTNET;
+    id = "ltc-test";
 
     majorityEnforceBlockUpgrade = MainNetParams.MAINNET_MAJORITY_ENFORCE_BLOCK_UPGRADE;
     majorityRejectBlockOutdated = MainNetParams.MAINNET_MAJORITY_REJECT_BLOCK_OUTDATED;
@@ -32,6 +34,6 @@ public class TestNet3Params extends org.bitcoinj.params.TestNet3Params {
 
   @Override
   public String getPaymentProtocolId() {
-    return PAYMENT_PROTOCOL_ID_REGTEST;
+    return PAYMENT_PROTOCOL_ID_TESTNET;
   }
 }


### PR DESCRIPTION
- fix test/private LTC params